### PR TITLE
put eqhp back to avg of mdef and pdef

### DIFF
--- a/src/legacy/services/statService.ts
+++ b/src/legacy/services/statService.ts
@@ -444,8 +444,7 @@ function statHelper(hCodeValues) {
       mdefEqHp.max = hp.max / (1 - mdefpc.max);
 
       var eqHp = calc.dupeStat(3008);
-      // eqHp.max = (pdefEqHp.max + mdefEqHp.max) / 2;
-      eqHp.max = pdefEqHp.max;
+      eqHp.max = (pdefEqHp.max + mdefEqHp.max) / 2;
       calc.addStat(eqHp);
 
       calc.addStat(str);


### PR DESCRIPTION
It was weird they max mdef in fdn - if you want the old calc just add heaps of mdef as a custom item